### PR TITLE
Fix: Correct task item color logic for due dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,17 +136,26 @@
             const diffTime = dueDate.getTime() - today.getTime();
             const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
-            if (diffDays < 0) return 'bg-red-500/30'; // Overdue
-            if (diffDays <= 1) return 'bg-red-500/30'; // Today and tomorrow
-            if (diffDays <= 2) return 'bg-orange-500/30'; // In 2 days
+            if (diffDays < 0) return 'bg-red-500/30';      // Overdue
+            if (diffDays === 0) return 'bg-red-500/30';     // Today
+            if (diffDays === 1) return 'bg-orange-500/30';  // Tomorrow
             
+            // For "within this week" excluding today and tomorrow
             const todayDay = today.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
             const endOfWeek = new Date(today);
-            endOfWeek.setDate(today.getDate() + (6 - todayDay)); // End of current week (Saturday)
+            // Calculate days remaining in the week. If today is Saturday (6), end of week is today.
+            // If today is Sunday (0), end of week is next Saturday (6 days away).
+            const daysUntilSaturday = (6 - todayDay + 7) % 7;
+            endOfWeek.setDate(today.getDate() + daysUntilSaturday);
+            endOfWeek.setHours(23,59,59,999); // Ensure end of week covers the entire last day
+
+            // Check if dueDate is after tomorrow and up to the end of the current week
+            if (diffDays > 1 && dueDate <= endOfWeek) {
+                return 'bg-green-500/30'; // Within this week (but not today or tomorrow)
+            }
             
-            if (dueDate <= endOfWeek) return 'bg-green-500/30'; // Within this week
-            
-            return 'bg-white/10'; // More than a week away
+            // Default for tasks further out
+            return 'bg-white/10';
         }
 
         /**


### PR DESCRIPTION
- Tasks due today or overdue are now correctly styled red.
- Tasks due tomorrow are styled orange.
- Tasks due later within the current week are styled green.
- Tasks due further than a week out or with no due date have distinct default styles.

This change addresses an issue where tasks due 'today' and 'tomorrow' were both incorrectly displayed with the same 'overdue' styling.